### PR TITLE
Fix: update 'date range'-based methods to consider the 'Date' part only of given DateTime values

### DIFF
--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeEnums/FourMonthPeriodOfYear/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeEnums/FourMonthPeriodOfYear/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils.DateTimeEnums](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Enum class encapsulating four month period of year.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeEnums/MonthOfYear/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeEnums/MonthOfYear/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils.DateTimeEnums](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Enum class representing months.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeEnums/QuarterOfYear/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeEnums/QuarterOfYear/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils.DateTimeEnums](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Enum class encapsulating quarters of the year.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Provides extension methods for DateTime, supporting equality check, week and weekends, days of months, quarters and four month periods.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/EndOfWeek.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/EndOfWeek.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the date of the week end (Monday set as default week start day) of the given date.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/EqualsByDate.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/EqualsByDate.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if two dates are equal by their Date property.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstDayOfFourMonthPeriod.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstDayOfFourMonthPeriod.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the first day of the date corresponding four mounth period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstDayOfMonth.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstDayOfMonth.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the first day of the given date month.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstDayOfQuarter.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstDayOfQuarter.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the first day of the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfFourMonthPeriod.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfFourMonthPeriod.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the ordinal number of the first month of the date corresponding four month period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfFourMonthPeriodOfYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfFourMonthPeriodOfYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an enum representing the first month of the date corresponding four month period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfQuarter.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfQuarter.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the ordinal number of the first month of the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfQuarterYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FirstMonthOfQuarterYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an enum representing the first month of the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FourMonthPeriod.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FourMonthPeriod.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the ordinal number of the date corresponding fourth month period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FourMonthPeriodOfYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/FourMonthPeriodOfYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an enum representing the date corresponding fourth month period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/IsWeekend.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/IsWeekend.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if the day of a given date is week end or not.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastDayOfFourMonthPeriod.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastDayOfFourMonthPeriod.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the last day of the date corresponding four mounth period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastDayOfMonth.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastDayOfMonth.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the last day of the given date month.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastDayOfQuarter.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastDayOfQuarter.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the last day of the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfFourMonthPeriod.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfFourMonthPeriod.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the ordinal number of the last month of the date corresponding four month period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfFourMonthPeriodOfYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfFourMonthPeriodOfYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an enum representing the last month of the date corresponding four month period.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfQuarter.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfQuarter.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the ordinal number of the last month of the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfQuarterYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/LastMonthOfQuarterYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an enum representing the last month of the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/MonthOfYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/MonthOfYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an enum representation of the given date month of year.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/Quarter.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/Quarter.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the ordinal number of the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/QuarterOfYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/QuarterOfYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an enum representing the date corresponding quarter.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/StartOfWeek.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeExtensions/methods/StartOfWeek.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the date of the week start (Monday set as default) of the given date.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Provides extension methods when working with DateTime objects related to national holidays.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsAllSaintsDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsAllSaintsDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is All Saints' Day (i.e. November 1st).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsAnniversaryOfTheUnificationOfItalyDayOfficiallyCelebrated.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsAnniversaryOfTheUnificationOfItalyDayOfficiallyCelebrated.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is the Anniversary of the Unification Of Italy: this official celebration occurres on March 17th and every 50 years from 1961 included.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsAssumptionOfMaryDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsAssumptionOfMaryDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Assumption of Mary Day (i.e. August 15th).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsChristmas.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsChristmas.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Christmas Day (i.e. December 25th).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsEpiphany.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsEpiphany.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Epiphany (i.e. January 6th, excluding occurrences from 1978 to 1984).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsImmaculateConceptionDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsImmaculateConceptionDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Immaculate Conception Day (i.e. December 8th).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsItalianLiberationDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsItalianLiberationDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Italian Liberation Day (i.e. April 25th).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsItalianNationalUnityAndArmedForcesDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsItalianNationalUnityAndArmedForcesDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Italian National Unity and Armed Forces Day (i.e. November 4th until 1977 excluded).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsItalianRepublicDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsItalianRepublicDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Italian Republic Day (i.e. June 2nd since 1946 excluded).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsNewYearsDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsNewYearsDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is New Year's Day.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsSaintJosephsDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsSaintJosephsDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Saint Joseph's Day (i.e. March 19th, until 1977 excluded).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsSaintStephensDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsSaintStephensDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Saint Stephen's Day (i.e. December 26th).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsSaintsPeterAndPaulFeast.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsSaintsPeterAndPaulFeast.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Saints Peter and Paul Feast (i.e. June 29th until 1977 excluded).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsWorkersDay.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateTimeHolidaysExtensions/methods/IsWorkersDay.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateTimeHolidaysExtensions](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if given date is Italian Workers' Day: from 1890 this day has been celebrated on May 1th during Late Modern Period, or during City of Rome foundation celebration day (i.e. April 21st, from 1924 to 1944, both included).
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateUtils/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateUtils/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Provides simple static DateTime utility methods.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateUtils/methods/GetDateTimeFromDateAsStringAndYear.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateUtils/methods/GetDateTimeFromDateAsStringAndYear.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the date time from a date formatted as string plus the year as an integer.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateUtils/methods/GetYearsBetweenDates.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/DateUtils/methods/GetYearsBetweenDates.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [DateUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets an array of years between two dates.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/fields/LocalHolidayCondition.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/fields/LocalHolidayCondition.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianHolidaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Represents a condition to consider a date as local holiday.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Provides static utility methods when working with Italian holidays checks.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/GetItalianHolidaysInRange.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/GetItalianHolidaysInRange.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianHolidaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets a DateTime list of Italian holidays between given dates.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/GetYearlyEaster.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/GetYearlyEaster.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianHolidaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the DateTime of Easter Sunday given the year.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/GetYearlyItalianHolidays.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/GetYearlyItalianHolidays.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianHolidaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets a DateTime list of yearly Italian holidays.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/IsHoliday.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianHolidaysUtils/methods/IsHoliday.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianHolidaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Tells if a particular date is an Italian (national or local) holiday or not.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/index.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/index.md
@@ -9,7 +9,7 @@
 
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Provides static utility methods when dealing with Italian work days calculations.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/methods/HowManyItalianOfficeDaysBetweenDates.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/methods/HowManyItalianOfficeDaysBetweenDates.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianWorkDaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the number of Italian office days between two given dates, removing weekends and Italian national and local holidays.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/methods/HowManyItalianWorkDaysBetweenDates.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/methods/HowManyItalianWorkDaysBetweenDates.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianWorkDaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Gets the number of Italian work days between two given dates, keeping those that match a given condition  but still removing Italian both national and local holidays.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/ExcludeSundaysCondition.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/ExcludeSundaysCondition.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianWorkDaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Function set up to exclude Sundays only.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/ExcludeWeekendsCondition.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/ExcludeWeekendsCondition.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianWorkDaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Function set up to exclude weekends.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/IncludeOnlyEvenDaysCondition.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/IncludeOnlyEvenDaysCondition.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianWorkDaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Function set up to include only even days.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/IncludeOnlyOddDaysCondition.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/IncludeOnlyOddDaysCondition.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianWorkDaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Function set up to include only odd days.
 

--- a/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/IncludeWeekendsCondition.md
+++ b/docs/generated/DavideBorghi/ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils/properties/IncludeWeekendsCondition.md
@@ -10,7 +10,7 @@
 **Declaring Type:** [ItalianWorkDaysUtils](../index.md)  
 **Namespace:** [DavideBorghi.ItalianDotNetDateTimeUtils](../../index.md)  
 **Assembly:** DavideBorghi.ItalianDotNetDateTimeUtils  
-**Assembly Version:** 2.0.0+47795d243b562f740038183afc91f1a19a4cde19
+**Assembly Version:** 2.0.0+8968417b34b75fc369cfc7d8f020d77fe99a2a50
 
 Function set up to include weekends.
 

--- a/src/DavideBorghi.ItalianDotNetDateTimeUtils/ItalianHolidaysUtils.cs
+++ b/src/DavideBorghi.ItalianDotNetDateTimeUtils/ItalianHolidaysUtils.cs
@@ -117,6 +117,9 @@ namespace DavideBorghi.ItalianDotNetDateTimeUtils
         /// <exception cref="ArgumentException">Thrown when one or both of the provided dates' year is before 1946.</exception>
         public static IEnumerable<DateTime> GetItalianHolidaysInRange(DateTime startDate, DateTime endDate)
         {
+            startDate = startDate.Date;
+            endDate = endDate.Date;
+
             if (startDate > endDate)
             {
                 throw new ArgumentException($"{nameof(startDate)} cannot be after {nameof(endDate)}");

--- a/src/DavideBorghi.ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils.cs
+++ b/src/DavideBorghi.ItalianDotNetDateTimeUtils/ItalianWorkDaysUtils.cs
@@ -63,6 +63,9 @@ namespace DavideBorghi.ItalianDotNetDateTimeUtils
         /// - or when one or both of the provided dates' year is before 1946.</exception>
         public static int HowManyItalianWorkDaysBetweenDates(DateTime startDate, DateTime endDate, Func<DateTime, bool> workDaysCondition)
         {
+            startDate = startDate.Date;
+            endDate = endDate.Date;
+
             if (startDate > endDate)
             {
                 throw new ArgumentException($"{nameof(startDate)} cannot be after {nameof(endDate)}");

--- a/test/DavideBorghi.ItalianDotNetDateTimeUtils.Tests/IntegrationTests/ItalianWorkDaysUtilsTests.cs
+++ b/test/DavideBorghi.ItalianDotNetDateTimeUtils.Tests/IntegrationTests/ItalianWorkDaysUtilsTests.cs
@@ -9,11 +9,36 @@ public sealed class ItalianWorkDaysUtilsTests
     #endregion
 
     [Theory]
+    [InlineData("2021-01-01", "2021-01-10", 4)] // January 1 and January 6, 2021 are both holidays, so 4 office days
+    [InlineData("2022-05-01", "2022-05-10", 7)] // May 1, 2022 is a holiday, so 7 office days
+    [InlineData("2022-12-24", "2022-12-31", 4)] // December 25 and December 26, 2022, are both holidays, so 4 office days
+    [InlineData("2023-07-01", "2023-07-10", 6)] // No holidays, but still weekends, so 6 office days
+    [InlineData("2023-11-01", "2023-11-10", 7)] // November 1, 2023 is a holiday, a weekend is present, so 7 office days
+    [InlineData("2023-12-25", "2023-12-26", 0)] // Christmas and Saint Stephen's Day, so 0 office days
+    [InlineData("2024-02-06", "2024-02-06", 1)] // Single office day
+    [InlineData("2024-02-01", "2024-02-11", 7)] // No holidays, but still weekends, so 7 office days
+    public void HowManyItalianOfficeDaysBetweenDates_ShouldReturnCorrectResult(string startDateString, string endDateString, int expectedWorkingDays)
+    {
+        // Arrange
+        DateTime startDate = DateTime.Parse(startDateString);
+        DateTime endDate = DateTime.Parse(endDateString);
+
+        // Act
+        int result = ItalianWorkDaysUtils.HowManyItalianOfficeDaysBetweenDates(startDate, endDate);
+
+        // Assert
+        Assert.Equal(expectedWorkingDays, result);
+    }
+
+    [Theory]
     [InlineData("2021-01-01", "2021-01-10", 4)] // January 1 and January 6, 2021 are both holidays, so 4 working days
     [InlineData("2022-05-01", "2022-05-10", 7)] // May 1, 2022 is a holiday, so 7 working days
     [InlineData("2022-12-24", "2022-12-31", 4)] // December 25 and December 26, 2022, are both holidays, so 4 working days
-    [InlineData("2023-07-01", "2023-07-10", 6)] // No holidays, but still weekends, so 6 working
-    [InlineData("2023-11-01", "2023-11-10", 7)] // November 1, 2023 is a holiday, a weekend is present, so 7 working
+    [InlineData("2023-07-01", "2023-07-10", 6)] // No holidays, but still weekends, so 6 working days
+    [InlineData("2023-11-01", "2023-11-10", 7)] // November 1, 2023 is a holiday, a weekend is present, so 7 working days
+    [InlineData("2023-12-25", "2023-12-26", 0)] // Christmas and Saint Stephen's Day, so 0 working days
+    [InlineData("2024-02-06", "2024-02-06", 1)] // Single working day
+    [InlineData("2024-02-01", "2024-02-11", 7)] // No holidays, but still weekends, so 7 working days
     public void HowManyItalianWorkDaysBetweenDates_ExcludingWeekends_ShouldReturnCorrectResult(string startDateString, string endDateString, int expectedWorkingDays)
     {
         // Arrange
@@ -22,6 +47,58 @@ public sealed class ItalianWorkDaysUtilsTests
 
         // Act
         int result = ItalianWorkDaysUtils.HowManyItalianWorkDaysBetweenDates(startDate, endDate, ItalianWorkDaysUtils.ExcludeWeekendsCondition);
+
+        // Assert
+        Assert.Equal(expectedWorkingDays, result);
+    }
+
+    [Theory]
+    [InlineData("2024-01-01", "2024-01-07", 4)] // January 1 and January 6, plus a Sunday, so 4 working days if we include Saturdays
+    [InlineData("2024-02-01", "2024-02-11", 9)] // No holidays, but still sundays, so 9 working days if we include Saturdays
+    public void HowManyItalianWorkDaysBetweenDates_ExcludeSundays_ShouldReturnCorrectResult(string startDateString, string endDateString, int expectedWorkingDays)
+    {
+        // Arrange
+        DateTime startDate = DateTime.Parse(startDateString);
+        DateTime endDate = DateTime.Parse(endDateString);
+
+        // Act
+        int result = ItalianWorkDaysUtils.HowManyItalianWorkDaysBetweenDates(startDate, endDate, ItalianWorkDaysUtils.ExcludeSundaysCondition);
+
+        // Assert
+        Assert.Equal(expectedWorkingDays, result);
+    }
+
+    [Theory]
+    [InlineData("2024-01-01", "2024-01-08", 3)] // January 1 and a weekend, so 3 even working days
+    [InlineData("2024-02-01", "2024-02-15", 5)] // No holidays, but still 2 weekends, so 5 even working days
+    public void HowManyItalianWorkDaysBetweenDates_ExcludeWeekends_TakeOnlyEvenDays_ShouldReturnCorrectResult(string startDateString, string endDateString, int expectedWorkingDays)
+    {
+        // Arrange
+        DateTime startDate = DateTime.Parse(startDateString);
+        DateTime endDate = DateTime.Parse(endDateString);
+        static bool excludeWeekendsAndTakeOnlyEvenDays(DateTime date)
+            => ItalianWorkDaysUtils.ExcludeWeekendsCondition(date) && ItalianWorkDaysUtils.IncludeOnlyEvenDaysCondition(date);
+
+        // Act
+        int result = ItalianWorkDaysUtils.HowManyItalianWorkDaysBetweenDates(startDate, endDate, excludeWeekendsAndTakeOnlyEvenDays);
+
+        // Assert
+        Assert.Equal(expectedWorkingDays, result);
+    }
+
+    [Theory]
+    [InlineData("2024-01-01", "2024-01-08", 2)] // January 1 and a weekend, so 2 odd working days
+    [InlineData("2024-02-01", "2024-02-15", 6)] // No holidays, but still 2 weekends, so 6 odd working days
+    public void HowManyItalianWorkDaysBetweenDates_ExcludeWeekends_TakeOnlyOddDays_ShouldReturnCorrectResult(string startDateString, string endDateString, int expectedWorkingDays)
+    {
+        // Arrange
+        DateTime startDate = DateTime.Parse(startDateString);
+        DateTime endDate = DateTime.Parse(endDateString);
+        static bool excludeWeekendsAndTakeOnlyOddDays(DateTime date)
+            => ItalianWorkDaysUtils.ExcludeWeekendsCondition(date) && ItalianWorkDaysUtils.IncludeOnlyOddDaysCondition(date);
+
+        // Act
+        int result = ItalianWorkDaysUtils.HowManyItalianWorkDaysBetweenDates(startDate, endDate, excludeWeekendsAndTakeOnlyOddDays);
 
         // Assert
         Assert.Equal(expectedWorkingDays, result);


### PR DESCRIPTION
This avoids having issues when passing DateTime params with different TimeSpan parts.